### PR TITLE
[front] API 呼び出しに関する修正

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,6 @@ dist-ssr
 .amplify
 amplify_outputs*
 amplifyconfiguration*
+
+# env files
+.env

--- a/src/api/tasks.ts
+++ b/src/api/tasks.ts
@@ -7,13 +7,15 @@ import {
 } from "@/constants/post-birth-data";
 import { fetcher } from "@/lib/fetcher";
 
-const TASKS_ENDPOINT = "https://hackathon202509-backend.onrender.com/tasks";
-
 type ScheduleItem = {
   id: number;
   text: string;
   time: string;
 };
+
+const API_PATH = '/tasks'
+
+const endpoint = `${import.meta.env.VITE_API_BASE_URL || 'http://localhost:8000'}${API_PATH}`;
 
 const isValidTodoItem = (value: unknown): value is TodoItem => {
   if (!value || typeof value !== "object") {
@@ -66,7 +68,7 @@ for (const entry of STATIC_SCHEDULE_FALLBACK) {
 Object.freeze(STATIC_SCHEDULE_FALLBACK);
 
 const fetchTodoList = async (path: string) => {
-  const raw = await fetcher<unknown>(`${TASKS_ENDPOINT}/${path}`);
+  const raw = await fetcher<unknown>(`${endpoint}/${path}`);
   if (!Array.isArray(raw)) {
     throw new Error("Invalid todo payload");
   }
@@ -76,7 +78,7 @@ const fetchTodoList = async (path: string) => {
 };
 
 const fetchSchedule = async () => {
-  const raw = await fetcher<unknown>(`${TASKS_ENDPOINT}/schedule`);
+  const raw = await fetcher<unknown>(`${endpoint}/schedule`);
   if (!Array.isArray(raw)) {
     throw new Error("Invalid schedule payload");
   }
@@ -85,9 +87,9 @@ const fetchSchedule = async () => {
   return parsed;
 };
 
-export function useSyncTasks(path = "pre-birth") {
+export function useSyncTasks(path = "pre_birth") {
   return useSwr<TodoItem[]>(
-    `${TASKS_ENDPOINT}/${path}`,
+    `${endpoint}/${path}`,
     () => fetchTodoList(path),
     {
       revalidateOnFocus: false,
@@ -97,10 +99,10 @@ export function useSyncTasks(path = "pre-birth") {
 
 export const usePostBirthTasks = () =>
   useSwr<TodoItem[]>(
-    `${TASKS_ENDPOINT}/post-birth`,
+    `${endpoint}/post_birth`,
     async () => {
       try {
-        const remote = await fetchTodoList("post-birth");
+        const remote = await fetchTodoList("post_birth");
         if (remote.length === 0) {
           throw new Error("Empty todo payload");
         }
@@ -118,7 +120,7 @@ export const usePostBirthTasks = () =>
 
 export const useSchedule = () =>
   useSwr<ScheduleItem[]>(
-    `${TASKS_ENDPOINT}/schedule`,
+    `${endpoint}/schedule`,
     async () => {
       try {
         const remote = await fetchSchedule();


### PR DESCRIPTION
## 📝 関連する課題 / Related Issues

無し

## ⛏ 変更内容 / Details of Changes

- .gitignore に .env を追加しました [2951b14ae78392995b09e129fdb362e6d211010c]
- API のエンドポイントを指定する際に環境変数を使用する形に修正しました (& エンドポイントのパスを修正しました) [2951b14ae78392995b09e129fdb362e6d211010c]

## 💬 備考 / Remarks

- API の URL を環境変数経由で指定するようにしたので、vercel の環境変数に以下を追加してください。

```env
VITE_API_BASE_URL=https://hackathon202509-backend.onrender.com
```

FYI
https://vercel.com/docs/environment-variables

レビュー、よろしくお願いします！

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Configurable API base URL via environment settings for easier deployment across environments.
- Bug Fixes
  - Improved reliability of fetching tasks and schedules by standardizing endpoints and paths.
  - More consistent behavior across task categories, reducing potential loading issues.
- Chores
  - Updated project settings to ignore local environment files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->